### PR TITLE
Add more Windows detail

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -49,16 +49,78 @@ Rebuild the ldconfig cache using
 	
 	sudo ldconfig
 
-	
+
 ### Windows
 
 Using vcpkg (https://github.com/microsoft/vcpkg) tool, you can install libgsl library
 
 	vcpkg install gsl:x64-windows
+
+SUGGESTION: Use GitBash command prompt for handling everything Git-related. The process described below will generally be performed in this context.
+
+
+#### vcpkg notes
+
+Be aware that your vcpkg may not be up-to-date. For example, you may get a warning similar to the one below:
+
+	Warning: Different source is available for vcpkg (2020.2.4 -> 2020.6.15). Use .\bootstrap-vcpkg.bat to update.
 	
-Then copy the files `gsl.dll`, `gslcblas.dll`, `gslcblas.lib` and `gsl.lib` to `%LIBRARY_PATH%wrap_library/library/C/lib`
+If you get such a warning, you will want to do as the warning suggests: Run the `bootstrap-vcpkg.bat` from the Gitbash command prompt in the vcpkg directory. When you do, you will see something similar to the following:
+
+	$ ./bootstrap-vcpkg.bat
+	
+	Building vcpkg.exe ...
+	
+	...
+	
+	Building vcpkg.exe... done.
+
+	Telemetry
+	---------
+	vcpkg collects usage data in order to help us improve your experience.
+	The data collected by Microsoft is anonymous.
+	You can opt-out of telemetry by re-running the bootstrap-vcpkg script with -disableMetrics,
+	passing --disable-metrics to vcpkg on the command line,
+	or by setting the VCPKG_DISABLE_METRICS environment variable.
+	
+	Read more about vcpkg telemetry at docs/about/privacy.md
+	
+Now that your vcpkg.exe is up-to-date fully, your `vcpkg install` command will work as expected. 
+
+#### vcpkg install results
+
+When the `vcpkg install gsl:x64-windows` command successfully completes, the results can be found in:
+
+	vcpkg/buildtrees/gsl/x64-windows-rel
+
+The next step is to copy the files `gsl.dll`, `gslcblas.dll`, `gslcblas.lib` and `gsl.lib` in the "rel" directory (above) to `%LIBRARY_PATH%wrap_library/library/C/lib`
+
 Where `%LIBRARY_PATH%` is where you clone/download `wrap_gsl` source code.
 On windows if you are using a DLL be sure the DLL is in your PATH when you execute the examples.
+
+NOTE: You will most likely find that the 'lib' directory under your `wrap_gsl/library/C` does not exist and you will need to create that folder.
+
+#### post-vcpkg glue code
+
+After successful creation of the `.dll` and `.lib` files (above), your last step is to ensure the `glue code` has been created. These instructions were written on the basis of Microsoft Visual Studio 2019. Because this final step depends on a local C compiler and the example is based on VS-2019, we suggest using the `x86_x64_Cross_Tools_Command_Prompt_for_VS_2019` to ensure the MSC compiler is in a properly formed environment.
+
+NOTE: If you have not already created a PATH to the EiffelStudio `bin` directory with `finish_freezing.exe` in it, you will want to do so from within the VS-2019 command prompt (above). For example: This example was performed on a Windows 10 box using x64 using EiffelStudio 20.05 Standard (vs GPL), so the temporarily added PATH looks like this:
+
+	set PATH=%PATH%;C:\Program Files\Eiffel Software\EiffelStudio 20.05 Standard\studio\spec\win64\bin
+
+Once your environment understands where to find `finish_freezing`, you can now successfully execute it. To do so successfully, you need to be in the correct directory. In this example, we are in the directory shown below and issue the `finish_freezing -library` command as shown below:
+
+	wrap_gsl\library\generated_wrapper\c\src>finish_freezing -library
+
+Part of the resulting execution of finish_freezing will be:
+
+	Creating ..\..\..\C\spec\msc_vc140\win64\lib
+        copy eif_gsl.lib ..\..\..\C\spec\msc_vc140\win64\lib\eif_gsl.lib
+        1 file(s) copied.
+
+The `eif_gsl.lib` file is required for the Eiffel `external` features to be able to reach out and use the compiled GSL C API code. You will also find a reference to this file in the `wrapc_gsl.ecf` Eiffel project file. This is a required dependency and all of the work above has been to get us to this goal.
+
+At this point, you ought to be able to open EiffelStudio and add the `wrapc_gsl.ecf` using the `wrapc_gsl_tests` target and successfully compile (or freeze) and then run the `version test` successfully!
 
 
 ## Status


### PR DESCRIPTION
Added more details to the Windows section, including nuances with vcpkg and finish_freezing, which are important steps that users may get "lost" on without this additional detail. It is not necessarily important to overload users with %MY_PATH% bits, but to also give them examples from a live working system. In this case my Windows 10 box is very common (I think), so I have used that as the basis for writing the examples. The reader ought to be smart enough to make adaptations for their particular machine and its directory structures.